### PR TITLE
Tests should now pass on both 1.6 and 1 => 1.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: [1]
+        julia-version: [1.6, 1]
         julia-arch: [x64]
         os: [ubuntu-latest]
     steps:


### PR DESCRIPTION
- 1.6 = long-term support (LTS) release
- 1.8 = latest stable release